### PR TITLE
Add Chronic support for modifiedSince in conversations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ group :development do
 end
 
 gem "httparty"
+gem "chronic"

--- a/helpscout.gemspec
+++ b/helpscout.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<reek>, ["~> 1.2.8"])
       s.add_dependency(%q<rdoc>, [">= 0"])
+      s.add_dependency(%q<chronic>, [">= 0.9.0"])
     end
   else
     s.add_dependency(%q<httparty>, [">= 0"])
@@ -59,6 +60,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<reek>, ["~> 1.2.8"])
     s.add_dependency(%q<rdoc>, [">= 0"])
+    s.add_dependency(%q<chronic>, [">= 0.9.0"])
   end
 end
 

--- a/lib/helpscout/base.rb
+++ b/lib/helpscout/base.rb
@@ -3,6 +3,7 @@ require "uri"
 require "httparty"
 require "helpscout/models"
 require "erb"
+require "chronic"
 
 module HelpScout
   class Base
@@ -193,8 +194,7 @@ module HelpScout
         options["status"] = status
       end
       if modifiedSince
-        # TODO: Check modifiedSince format. Needs to be Datetime in UTC
-        options["modifiedSince"] = modifiedSince
+        options["modifiedSince"] = Chronic.parse(modifiedSince).strftime("%Y-%m-%dT%H:%M:%SZ")
       end
 
       conversations = []


### PR DESCRIPTION
Hated always having to put dates into this UTC format (without the "UTC"). Saw your "TODO" and thought be able to help.

Seemed like Chronic would make queries like this easier:

```
conversations = HelpScout::Base.conversations(mailbox.id, "all", "last week")
```

And would also handle dates mistakenly entered without the required **H** and **Z**.

I'm assuming the HelpScout guys are planning to add more `modifiedSince` params into their queries in the future, so this will be useful for more than just one method then :smile: 
