### PR TITLE
Return a Customer object after creating a new customer at Helpscout

### DIFF
--- a/lib/helpscout/client.rb
+++ b/lib/helpscout/client.rb
@@ -897,11 +897,10 @@ module HelpScout
       end
 
       url = "/customers.json"
-      params = JSON.parse(customer.to_json)
 
       begin
-        response = Client.create_item(@auth, url, customer.to_json)
-        true
+        item = Client.create_item(@auth, url, customer.to_json)
+        Customer.new(item)
       rescue StandardError => e
         puts "Could not create customer: #{e.message}"
         false


### PR DESCRIPTION
Instead of just returning true, this is a small change that returns a new Customer object after create_customer is called.
